### PR TITLE
Make test more robust against rewrites.

### DIFF
--- a/src/app/code/community/FireGento/AdminMonitoring/Test/Model/History/Data.php
+++ b/src/app/code/community/FireGento/AdminMonitoring/Test/Model/History/Data.php
@@ -88,11 +88,14 @@ class FireGento_AdminMonitoring_Test_Model_History_Data extends EcomDev_PHPUnit_
 
     /**
      * @test
-     * @loadFixture historyDataCmsPage
      */
     public function getObjectType()
     {
-        $model = $this->_getModel();
+        $object = new Mage_Cms_Model_Page();
+
+        /** @var FireGento_AdminMonitoring_Model_History_Data $model */
+        $model  = Mage::getModel('firegento_adminmonitoring/history_data', $object);
+
         $this->assertEquals('Mage_Cms_Model_Page', $model->getObjectType());
     }
 


### PR DESCRIPTION
Make this test independent of any rewrites for cms/page model. Before, having cms/page model rewritten to another class would let this test fail incorrectly, because get_class would return Rewritten_Cms_Page_Model.