### PR TITLE
Reduce memory usage while cleaning up

### DIFF
--- a/src/app/code/community/FireGento/AdminMonitoring/Model/Clean.php
+++ b/src/app/code/community/FireGento/AdminMonitoring/Model/Clean.php
@@ -27,8 +27,20 @@
  */
 class FireGento_AdminMonitoring_Model_Clean
 {
-    const XML_PATH_ADMINMONITORING_INTERVAL = 'admin/firegento_adminmonitoring/interval';
+    const XML_PATH_ADMINMONITORING_INTERVAL      = 'admin/firegento_adminmonitoring/interval';
     const XML_PATH_ADMINMONITORING_CLEAN_ENABLED = 'admin/firegento_adminmonitoring/enable_cleaning';
+
+    /**
+     * Clean in chunks.
+     *
+     * CHUNK_SIZE determines the items cleared per chunk.
+     *
+     * CHUNK_RUNS determines the number of chunks cleaned per call to clean()
+     *
+     * I.e. per call of clean(), at most CHUNK_SIZE * CHUNK_RUNS items are cleaned.
+     */
+    const CHUNK_SIZE = 1000;
+    const CHUNK_RUNS = 250;
 
     /**
      * Cronjob method for cleaning the database table.
@@ -63,11 +75,39 @@ class FireGento_AdminMonitoring_Model_Clean
             return $this;
         }
 
+        $this->cleanInChunks();
+
+        return $this;
+    }
+
+    /**
+     * Clean the database table for the given interval, usink chunks to avoid memory over-usage.
+     *
+     * @return $this
+     */
+    protected function cleanInChunks()
+    {
+        $numChunks = 0;
+        do {
+            $cleanedItems = $this->cleanChunk();
+        } while ($cleanedItems == static::CHUNK_SIZE && $numChunks++ < static::CHUNK_RUNS);
+
+        return $this;
+    }
+
+    /**
+     * Clean a chunk of the items in database table for the given interval.
+     *
+     * @return int Number of items deleted
+     */
+    protected function cleanChunk()
+    {
         $interval = Mage::getStoreConfig(self::XML_PATH_ADMINMONITORING_INTERVAL);
 
         /* @var $adminMonitoringCollection FireGento_AdminMonitoring_Model_Resource_History_Collection */
         $adminMonitoringCollection = Mage::getModel('firegento_adminmonitoring/history')
             ->getCollection()
+            ->setPageSize(static::CHUNK_SIZE)
             ->addFieldToFilter(
                 'created_at',
                 array(
@@ -75,10 +115,13 @@ class FireGento_AdminMonitoring_Model_Clean
                 )
             );
 
+        $count = 0;
+
         foreach ($adminMonitoringCollection as $history) {
             $history->delete();
+            $count++;
         }
 
-        return $this;
+        return $count;
     }
 }


### PR DESCRIPTION
PHP ran out of memory while cleaning up as out collection of things to delete grew too large one day.

This can be avoided by loading the items to delete in smaller chunks, which is implemented here.