### PR TITLE
Update adminmonitoring.xml

### DIFF
--- a/src/app/code/community/FireGento/AdminMonitoring/etc/adminmonitoring.xml
+++ b/src/app/code/community/FireGento/AdminMonitoring/etc/adminmonitoring.xml
@@ -8,6 +8,7 @@
                 <Enterprise_Logging_Model_Event/>
                 <!-- omit infinite loops -->
                 <FireGento_AdminMonitoring_Model_History/>
+                <Mage_Oauth_Model_Nonce/>
             </object_types>
             <fields>
                 <created_at/>


### PR DESCRIPTION
prevent from logging Mage_Oauth_Model_Nonce class into history
resolves https://github.com/firegento/firegento-adminmonitoring/issues/25