### PR TITLE
Fix unittests

### DIFF
--- a/src/app/code/community/FireGento/AdminMonitoring/Test/Block/Adminhtml/History.php
+++ b/src/app/code/community/FireGento/AdminMonitoring/Test/Block/Adminhtml/History.php
@@ -24,7 +24,7 @@
  *
  * @group FireGento_AdminMonitoring
  */
-class FireGento_AdminMonitoring_Test_Block_Adminhtml_History extends EcomDev_PHPUnit_Test_Case
+class FireGento_AdminMonitoring_Test_Block_Adminhtml_History extends EcomDev_PHPUnit_Test_Case_Controller
 {
     /**
      * @var FireGento_AdminMonitoring_Block_Adminhtml_History

--- a/src/app/code/community/FireGento/AdminMonitoring/Test/Config/Config.php
+++ b/src/app/code/community/FireGento/AdminMonitoring/Test/Config/Config.php
@@ -32,12 +32,10 @@ class FireGento_AdminMonitoring_Test_Config_Config extends EcomDev_PHPUnit_Test_
      */
     public function globalConfig()
     {
-        $this->assertModuleVersion($this->expected('module')->getVersion());
         $this->assertModuleCodePool($this->expected('module')->getCodePool());
 
         $this->assertSetupResourceDefined();
         $this->assertSetupResourceExists();
-        $this->assertSetupScriptVersions();
 
         $this->assertTableAlias('firegento_adminmonitoring/history', 'firegento_adminmonitoring_history');
     }


### PR DESCRIPTION
May replace #37 

After updating to phpunit 4.8 and using ecomdev_phpunit on latest develop version, we encountered headers already sent errors on the History block test.

Fabian Schmengler suggested using the Controller test case for this which takes care of cases where cookies/sessions are used.