### PR TITLE
Fixed models with constructor parameters

### DIFF
--- a/src/app/code/community/FireGento/AdminMonitoring/Model/History/Data.php
+++ b/src/app/code/community/FireGento/AdminMonitoring/Model/History/Data.php
@@ -61,8 +61,8 @@ class FireGento_AdminMonitoring_Model_History_Data
     public function getContent()
     {
         // have to re-load the model as based on database datatypes the format of values changes
-        $className = get_class($this->_savedModel);
-        $model = new $className;
+        $model = clone $this->_savedModel;
+        $model->setData(array());
 
         // Add store id if given
         if ($storeId = $this->_savedModel->getStoreId()) {


### PR DESCRIPTION
If I have some model that needs parameters:

```php
<?php

class Vendor_Module_Model_Example extends Mage_Core_Model_Abstract
{

    protected $_myDep;

    public function __construct(array $dependencies)
    {
        parent::__construct();

        if (isset($dependencies['mydep']) && ($attributes['mydep'] instanceof MyDep)) {
            $this->_myDep = $attributes['mydep'];
        } else {
            throw new ArgumentCountError('Too few arguments to function ' . __FUNCTION__);
        }
    }

   ....
}

//using model:
Mage::getModel('vendor_module/example', array('mydep' => new MyDep));

```


Then calling `$model = new $className;` in adminmonitoring on line
```
src/app/code/community/FireGento/AdminMonitoring/Model/History/Data.php:65
```

throws exception. My fix clones the object, so dependencies are kept and there is no need to call constructor. Clears data by setting empty array before load.